### PR TITLE
SNAP-2213

### DIFF
--- a/docker/kubernetes/snappy-ui-proxy.yml
+++ b/docker/kubernetes/snappy-ui-proxy.yml
@@ -1,7 +1,8 @@
-# This Python script creates a lightweight HTTP server that proxies all the requests 
+# This deployment creates a lightweight HTTP server that proxies all the requests 
 # to your Snappy members. All you have to do is connect to the Pulse dashboard 
 # and all links within be functional
 # Looks for k8s object snappydata-leader and forwards to port 5050
+# List out all the services using kubectl and use <snappy-ui-proxy IP>:5050 to access the UI.
 # TODO: There must be a better way to do this -- Jags
 kind: ReplicationController
 apiVersion: v1

--- a/docker/kubernetes/snappy-ui-proxy.yml
+++ b/docker/kubernetes/snappy-ui-proxy.yml
@@ -1,0 +1,48 @@
+# This Python script creates a lightweight HTTP server that proxies all the requests 
+# to your Snappy members. All you have to do is connect to the Pulse dashboard 
+# and all links within be functional
+# Looks for k8s object snappydata-leader and forwards to port 5050
+# TODO: There must be a better way to do this -- Jags
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: snappy-ui-proxy-controller
+spec:
+  replicas: 1
+  selector:
+    component: snappy-ui-proxy
+  template:
+    metadata:
+      labels:
+        component: snappy-ui-proxy
+    spec:
+      containers:
+        - name: snappy-ui-proxy
+          image: elsonrodriguez/spark-ui-proxy:1.0
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+          args:
+            - snappydata-leader:5050
+          livenessProbe:
+              httpGet:
+                path: /
+                port: 80
+              initialDelaySeconds: 120
+              timeoutSeconds: 5
+ 
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: snappy-ui-proxy
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    component: snappy-ui-proxy
+  type: LoadBalancer
+

--- a/docker/kubernetes/snappydata-cluster.yml
+++ b/docker/kubernetes/snappydata-cluster.yml
@@ -76,8 +76,10 @@ spec:
         image: snappydatainc/snappydata:1.0.0
         imagePullPolicy: IfNotPresent
         resources:
-        requests:
-          memory: "1024Mi"
+          limits:
+            memory: 1024Mi
+          requests:
+            memory: 512Mi
 #         cpu: "200m"
         ports:
         - containerPort: 10334
@@ -100,8 +102,8 @@ spec:
         - mountPath: "/opt/snappydata/work"
           name: snappy-disk-claim
 
-  terminationGracePeriodSeconds: 60
-  
+      terminationGracePeriodSeconds: 60
+
   volumeClaimTemplates:
   - metadata:
       name: snappy-disk-claim
@@ -111,6 +113,7 @@ spec:
         requests:
           storage: 10Gi
       storageClassName: standard
+
 # A PV claim using 'standard' storage class. Will work only in Google container engine. 
 # In other clouds, create a PV and assign storageClassName ...
 
@@ -159,7 +162,7 @@ spec:
         - mountPath: "/opt/snappydata/work"
           name: snappy-disk-claim
       terminationGracePeriodSeconds: 60
-  
+
   volumeClaimTemplates:
   - metadata:
       name: snappy-disk-claim
@@ -169,7 +172,7 @@ spec:
         requests:
           storage: 10Gi
       storageClassName: standard
-# A PV claim using 'standard' storage class. Will work only in Google container engine. 
+# A PV claim using 'standard' storage class. Will work only in Google container engine.
 # In other clouds, create a PV and assign storageClassName ...
 
 
@@ -216,7 +219,7 @@ spec:
         - mountPath: "/opt/snappydata/work"
           name: snappy-disk-claim
       terminationGracePeriodSeconds: 60
-  
+
   volumeClaimTemplates:
   - metadata:
       name: snappy-disk-claim
@@ -226,7 +229,7 @@ spec:
         requests:
           storage: 10Gi
       storageClassName: standard
-# A PV claim using 'standard' storage class. Will work only in Google container engine. 
+# A PV claim using 'standard' storage class. Will work only in Google container engine.
 # In other clouds, create a PV and assign storageClassName ...
 
 ---

--- a/docker/kubernetes/snappydata-cluster.yml
+++ b/docker/kubernetes/snappydata-cluster.yml
@@ -1,0 +1,232 @@
+# Launch Snappydata 1.0.0 cluster on k8s 1.9
+# Submit using kubectl will create services for Locator, server and leader. 
+# The services provide access to port 1527 for the locator and server. 
+# The leader service opens the Pulse UI on port 5050
+#
+# Then, we launch 3 statefulSet pods each for Locator, server, Leader. 
+# Scale using the replica count below. 
+# Adjust CPU, memory to suit your needs. 
+# 
+apiVersion: v1
+kind: Service
+metadata:
+  name: snappydata-locator
+  labels:
+    app: snappydata
+spec:
+  ports:
+  - port: 1527
+    targetPort: 1527
+    name: jdbc
+  - port: 10334
+    targetPort: 10334
+    name: locator-clustering-endpoint
+  type: LoadBalancer
+  selector:
+    app: snappydata-locator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: snappydata-server
+  labels:
+    app: snappydata
+spec:
+  ports:
+  - port: 1527
+    targetPort: 1527
+    name: jdbc
+  type: LoadBalancer
+  selector:
+    app: snappydata-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: snappydata-leader
+  labels:
+    app: snappydata
+spec:
+  ports:
+  - port: 5050
+    targetPort: 5050
+    name: spark
+  type: LoadBalancer
+  selector:
+    app: snappydata-leader
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: snappydata-locator
+spec:
+  serviceName: snappydata-locator
+  replicas: 1
+  selector:
+    matchLabels:
+      app: snappydata-locator
+  template:
+    metadata:
+      labels:
+        app: snappydata-locator
+    spec:
+      containers:
+      - name: snappydata-locator
+        image: snappydatainc/snappydata:1.0.0
+        imagePullPolicy: IfNotPresent
+        resources:
+        requests:
+          memory: "1024Mi"
+#         cpu: "200m"
+        ports:
+        - containerPort: 10334
+          name: locator
+        - containerPort: 1527
+          name: jdbc
+     # primitive liveness probe .. only useful when the JVM crashes
+        livenessProbe:
+          tcpSocket:
+            port: 1527
+          initialDelaySeconds: 80
+        command: ["/bin/bash", "-c"]
+        args: ["start locator"]
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /opt/snappydata/sbin/snappy-locators.sh stop
+        volumeMounts:
+        - mountPath: "/opt/snappydata/work"
+          name: snappy-disk-claim
+
+  terminationGracePeriodSeconds: 60
+  
+  volumeClaimTemplates:
+  - metadata:
+      name: snappy-disk-claim
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: standard
+# A PV claim using 'standard' storage class. Will work only in Google container engine. 
+# In other clouds, create a PV and assign storageClassName ...
+
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: snappydata-server
+spec:
+  serviceName: snappydata-server
+  replicas: 2
+  selector:
+    matchLabels:
+      app: snappydata-server
+  template:
+    metadata:
+      labels:
+        app: snappydata-server
+    spec:
+      containers:
+      - name: snappydata-server
+        image: snappydatainc/snappydata:1.0.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            memory: "2048Mi"
+#           cpu: "1000m"
+        # Even servers use the same port as locator ... all run on independent pods
+        # ... and, the service will either roundrobin or loadbalance
+        ports:
+        - containerPort: 1527
+          name: jdbc
+        livenessProbe:
+          tcpSocket:
+            port: 1527
+          initialDelaySeconds: 160
+        command: ["/bin/bash", "-c"]
+        args: ["sleep 15; start server -locators=snappydata-locator:10334 -client-port=1527 -J-Dgemfirexd.hostname-for-clients=snappydata-server-public ; sleep 10000000"]
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /opt/snappydata/sbin/snappy-servers.sh stop
+        volumeMounts:
+        - mountPath: "/opt/snappydata/work"
+          name: snappy-disk-claim
+      terminationGracePeriodSeconds: 60
+  
+  volumeClaimTemplates:
+  - metadata:
+      name: snappy-disk-claim
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: standard
+# A PV claim using 'standard' storage class. Will work only in Google container engine. 
+# In other clouds, create a PV and assign storageClassName ...
+
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: snappydata-leader
+spec:
+  serviceName: snappydata-leader
+  replicas: 1
+  selector:
+    matchLabels:
+      app: snappydata-leader
+  template:
+    metadata:
+      labels:
+        app: snappydata-leader
+    spec:
+      containers:
+      - name: snappydata-leader
+        image: snappydatainc/snappydata:1.0.0
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            memory: "1024Mi"
+#            cpu: "1000m"
+        ports:
+        - containerPort: 5050
+          name: sparkui
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 5050
+          initialDelaySeconds: 160
+        command: ["/bin/bash", "-c"]
+        args: ["sleep 15; start lead -locators=snappydata-locator:10334 ; sleep 1000000"]
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /opt/snappydata/sbin/snappy-leads.sh stop
+        volumeMounts:
+        - mountPath: "/opt/snappydata/work"
+          name: snappy-disk-claim
+      terminationGracePeriodSeconds: 60
+  
+  volumeClaimTemplates:
+  - metadata:
+      name: snappy-disk-claim
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 10Gi
+      storageClassName: standard
+# A PV claim using 'standard' storage class. Will work only in Google container engine. 
+# In other clouds, create a PV and assign storageClassName ...
+
+---

--- a/docker/kubernetes/snappydata.yml
+++ b/docker/kubernetes/snappydata.yml
@@ -1,4 +1,7 @@
-# SnappyData Version 0.6 ( latest )
+#TODO: this is stale but someone could see if the Prometheus annotations have value. 
+# If not, DELETE from repo. 
+#
+# SnappyData latest Version 
 apiVersion: v1
 kind: Service
 metadata:
@@ -110,8 +113,8 @@ spec:
   selector:
     app: snappydata-leader
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: snappydata-locator
 spec:
@@ -128,10 +131,10 @@ spec:
       - name: snappydata-locator
         # Runs the current snappydata release
         image: snappydatainc/snappydata
-        imagePullPolicy: Always
+        # imagePullPolicy: Always
         resources:
           requests:
-            memory: "2048Mi"
+            memory: "500Mi"
             cpu: "200m"
         ports:
         - containerPort: 10334
@@ -158,8 +161,8 @@ spec:
               - /opt/snappydata/sbin/snappy-locators.sh stop
       terminationGracePeriodSeconds: 60
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: snappydata-server
 spec:
@@ -176,13 +179,13 @@ spec:
       - name: snappydata-server
         # Runs the current snappydata release
         image: snappydatainc/snappydata
-        imagePullPolicy: Always
+        # imagePullPolicy: Always
         args:
         - sleep
         - "1000000"
         resources:
           requests:
-            memory: "2048Mi"
+            memory: "1024Mi"
             cpu: "1000m"
         ports:
         - containerPort: 1527
@@ -207,8 +210,8 @@ spec:
               - /opt/snappydata/sbin/snappy-servers.sh stop
       terminationGracePeriodSeconds: 60
 ---
-apiVersion: apps/v1alpha1
-kind: PetSet
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: snappydata-leader
 spec:
@@ -228,7 +231,7 @@ spec:
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "4096Mi"
+            memory: "1024Mi"
             cpu: "1000m"
         ports:
         - containerPort: 5050


### PR DESCRIPTION
1. A yaml to proxy access to the leader Pulse so all the links work. This proxy makes the UI slow though.
2. Now you can launch Snappy data cluster on k8s 1.9 and using the Snappy GA version.
3. This provides access from external clients, exports the UI endpoints, and uses persistent volume (tested only on GKE).
4.  Now you can launch Snappy data cluster on k8s 1.9 and using the Snappy GA version.

This provides access from external clients, exports the UI endpoints, and uses persistent volume (tested only on GKE).
Would be good if someone else gives this a try using either minikube or GKE. 