### PR TITLE
Maintenance fixes.

### DIFF
--- a/aws/ec2/deploy/home/ec2-user/snappydata/aws-shutdown.sh
+++ b/aws/ec2/deploy/home/ec2-user/snappydata/aws-shutdown.sh
@@ -28,18 +28,5 @@ else
   sh "${SNAPPY_HOME_DIR}/sbin/snappy-stop-all.sh"
 fi
 
-for node in $LOCATORS; do
-  ssh -t "$node" "sudo cp /etc/hosts.orig /etc/hosts; cp ~/.ssh/known_hosts.orig ~/.ssh/known_hosts"
-done
-
-for node in $LEADS; do
-  ssh -t "$node" "sudo cp /etc/hosts.orig /etc/hosts; cp ~/.ssh/known_hosts.orig ~/.ssh/known_hosts"
-done
-
-for node in $SERVERS; do
-  ssh -t "$node" "sudo cp /etc/hosts.orig /etc/hosts; cp ~/.ssh/known_hosts.orig ~/.ssh/known_hosts"
-done
-
-
 popd > /dev/null
 

--- a/aws/ec2/deploy/home/ec2-user/snappydata/fetch-distribution.sh
+++ b/aws/ec2/deploy/home/ec2-user/snappydata/fetch-distribution.sh
@@ -35,7 +35,7 @@ extract() {
 }
 
 getLatestUrl() {
-  URL="https://github.com/SnappyDataInc/snappydata/releases/download/v1.0.0/snappydata-1.0.0-bin.tar.gz"
+  URL="https://github.com/SnappyDataInc/snappydata/releases/download/v1.0.1/snappydata-1.0.1-bin.tar.gz"
 }
 
 SNAPPY_HOME_DIR="snappydata-${SNAPPYDATA_VERSION}-bin"

--- a/aws/ec2/deploy/home/ec2-user/snappydata/zeppelin-setup.sh
+++ b/aws/ec2/deploy/home/ec2-user/snappydata/zeppelin-setup.sh
@@ -37,10 +37,9 @@ echo "${LEADS}" > lead_list
 FIRST_LEAD=`cat lead_list | sed -n '1p'`
 
 ZEP_VERSION="0.7.3"
-INTERPRETER_VERSION="0.7.2"
+INTERPRETER_VERSION="0.7.3"
 ZEP_DIR="zeppelin-${ZEP_VERSION}-bin-netinst"
-ZEP_URL_MIRROR="http://www-us.apache.org/dist/zeppelin/zeppelin-${ZEP_VERSION}/${ZEP_DIR}.tgz"
-ZEP_ALT_URL="http://www-eu.apache.org/dist/zeppelin/zeppelin-${ZEP_VERSION}/${ZEP_DIR}.tgz"
+ZEP_URL_MIRROR="http://archive.apache.org/dist/zeppelin/zeppelin-${ZEP_VERSION}/${ZEP_DIR}.tgz"
 ZEP_NOTEBOOKS_URL="https://github.com/SnappyDataInc/zeppelin-interpreter/raw/notes/examples/notebook"
 ZEP_NOTEBOOKS_DIR="notebook"
 PUBLIC_HOSTNAME=`wget -q -O - http://169.254.169.254/latest/meta-data/public-hostname`
@@ -50,13 +49,7 @@ if [[ ! -d ${ZEP_DIR} ]]; then
   if [[ ! -e "${ZEP_DIR}.tgz" ]]; then
     echo "Downloading Apache Zeppelin distribution..."
     wget -q "${ZEP_URL_MIRROR}"
-    # TODO while loop
-    if [ $? -ne 0 ]; then
-      # Try different mirror.
-      rm "${ZEP_DIR}.tgz"
-      wget -q "${ZEP_ALT_URL}"
-    fi
-    
+    # TODO exit if download fails
   fi
   tar -xf "${ZEP_DIR}.tgz"
 fi
@@ -79,7 +72,7 @@ if [[ ! -d ${SNAPPY_HOME_DIR} ]]; then
 fi
 
 # Download, extract and place SnappyData interpreter under interpreter/ directory
-INTERPRETER_JAR="snappydata-zeppelin-${INTERPRETER_VERSION}.jar"
+INTERPRETER_JAR="snappydata-zeppelin_2.11-${INTERPRETER_VERSION}.jar"
 INTERPRETER_URL="https://github.com/SnappyDataInc/zeppelin-interpreter/releases/download/v${INTERPRETER_VERSION}/${INTERPRETER_JAR}"
 INTERPRETER_DIR="${ZEP_DIR}/interpreter/snappydata"
 

--- a/aws/ec2/snappy_ec2.py
+++ b/aws/ec2/snappy_ec2.py
@@ -60,7 +60,7 @@ else:
     xrange = range
 
 
-SNAPPY_EC2_VERSION = "0.8"
+SNAPPY_EC2_VERSION = "0.8.1"
 SNAPPY_EC2_DIR = os.path.dirname(os.path.realpath(__file__))
 SNAPPY_AWS_CONF_DIR = SNAPPY_EC2_DIR + "/deploy/home/ec2-user/snappydata"
 SNAPPYDATA_UI_PORT = ""
@@ -221,7 +221,7 @@ def parse_args():
 #        help="Version of SnappyData to use: 'X.Y.Z' (default: %default)")
     parser.add_option(
         "--enterprise", action="store_true", default=False,
-        help="Use SnappyData Enterprise edition AMI from AWS Marketplace to launch the cluster. " +
+        help="(Will be supported soon) Use SnappyData Enterprise edition AMI from AWS Marketplace to launch the cluster. " +
              "Overrides --ami option. Extra charges apply. (default: %default)")
     parser.add_option(
         "--with-zeppelin", action="store_true", default=False,
@@ -316,8 +316,8 @@ def parse_args():
     (action, cluster_name) = args
 
     if opts.enterprise:
-        print("SnappyData Enterprise AMIs will soon be available on AWS Marketplace.")
-        print("Exiting the cluster %s process." % action)
+        print("SnappyData Enterprise AMIs are available on AWS Marketplace.")
+        print("These will be supported by the EC2 scripts soon. Exiting the cluster %s process." % action)
         sys.exit(1)
         print("You selected SnappyData Enterprise edition AMI to launch the cluster {c}. " +
         "It'll incur extra charges.".format(c=cluster_name))


### PR DESCRIPTION
* Updated download links to point to latest distribution (SnappyData 1.0.1 and Zeppelin interpreter 0.7.3)
* Calculate and update heap to be 80% of available memory.
* Use correct download links for Zeppelin distribution.
* Some minor fixes